### PR TITLE
added monitoring tools for feature, model serving, and dashboard

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,8 +127,7 @@ services:
     ports:
       - "9090:9090"
     volumes:
-      # - ./devops/docker-compose/prometheus.yml:/etc/prometheus/prometheus.yml
-      - ./devops/docker-compose/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
@@ -151,8 +150,8 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=admin
       - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
     volumes:
-      - ./devops/docker-compose/grafana/provisioning:/etc/grafana/provisioning
-      - ./devops/docker-compose/grafana/dashboards:/etc/grafana/provisioning/dashboards
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning
+      - ./monitoring/grafana/dashboards:/etc/grafana/provisioning/dashboards
       - grafana_data:/var/lib/grafana
     restart: unless-stopped
     depends_on:

--- a/feature_serving/main.py
+++ b/feature_serving/main.py
@@ -10,6 +10,9 @@ from starlette.concurrency import run_in_threadpool
 from datetime import date # Import date for type hinting
 from typing import Optional
 
+# Prometheus Instrumentation
+from prometheus_fastapi_instrumentator import Instrumentator
+
 from .config import settings
 # Import the data loading function and connection management functions
 from .data_loader import (
@@ -53,6 +56,11 @@ app = FastAPI(
     description="Provides weather features for yield prediction.",
     version="1.0.0"
 )
+
+# --- Add Prometheus Metrics ---
+# Instrument before adding routes or other middleware if it matters for those
+Instrumentator().instrument(app).expose(app)
+# ----------------------------
 
 # --- Startup and Shutdown Events for Swift Connection ---
 @app.on_event("startup")

--- a/feature_serving/pyproject.toml
+++ b/feature_serving/pyproject.toml
@@ -14,7 +14,9 @@ pandas = "^2.1.2" # Or the version you installed
 pydantic-settings = "^2.0.3" # Or the version you installed
 structlog = "^23.2.0" # Or the version you installed
 openstacksdk = "^1.2.0" # Or the version you installed
-keystoneauth1 = "^5.10.0" 
+keystoneauth1 = "^5.10.0"
+prometheus-client = "^0.19.0"
+prometheus-fastapi-instrumentator = "^6.1.0"
 
 
 [build-system]

--- a/monitoring/grafana/dashboards/default.json
+++ b/monitoring/grafana/dashboards/default.json
@@ -1,0 +1,60 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "title": "Model Serving Requests",
+      "type": "graph",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "rate(fastapi_requests_total{job=\"model-serving\"}[5m])",
+          "legendFormat": "{{handler}}"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 }
+    },
+    {
+      "title": "Dashboard Page Views",
+      "type": "stat",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "dashboard_page_views_total",
+          "legendFormat": "Page Views"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 }
+    }
+  ],
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Service Overview",
+  "uid": "services-overview",
+  "version": 1
+} 

--- a/monitoring/grafana/provisioning/dashboards/default.json
+++ b/monitoring/grafana/provisioning/dashboards/default.json
@@ -1,0 +1,278 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "title": "Model Serving: Request Rate",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "targets": [
+        {
+          "expr": "rate(fastapi_requests_total{job=\"model-serving\"}[5m])",
+          "legendFormat": "requests/sec",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          }
+        }
+      ],
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 0 },
+      "description": "Rate of requests to the model serving API."
+    },
+    {
+      "title": "Model Serving: P95 Latency",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(fastapi_request_duration_seconds_bucket{job=\"model-serving\"}[5m])) by (le))",
+          "legendFormat": "P95 Latency",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          }
+        }
+      ],
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 0 },
+      "unit": "s",
+      "description": "95th percentile request latency for model serving."
+    },
+    {
+      "title": "Model Serving: Error Rate (5xx)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(fastapi_requests_total{job=\"model-serving\",status_code=~\"5..\"}[5m])) / sum(rate(fastapi_requests_total{job=\"model-serving\"}[5m])) * 100",
+          "legendFormat": "Error %",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          }
+        }
+      ],
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 0 },
+      "unit": "percent",
+      "description": "Percentage of 5xx errors for model serving."
+    },
+    {
+      "title": "Feature Serving: Request Rate",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "targets": [
+        {
+          "expr": "rate(fastapi_requests_total{job=\"feature-serving\"}[5m])",
+          "legendFormat": "requests/sec",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          }
+        }
+      ],
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 8 },
+      "description": "Rate of requests to the feature serving API."
+    },
+    {
+      "title": "Feature Serving: P95 Latency",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(fastapi_request_duration_seconds_bucket{job=\"feature-serving\"}[5m])) by (le))",
+          "legendFormat": "P95 Latency",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          }
+        }
+      ],
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 8 },
+      "unit": "s",
+      "description": "95th percentile request latency for feature serving."
+    },
+    {
+      "title": "Feature Serving: Error Rate (5xx)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(fastapi_requests_total{job=\"feature-serving\",status_code=~\"5..\"}[5m])) / sum(rate(fastapi_requests_total{job=\"feature-serving\"}[5m])) * 100",
+          "legendFormat": "Error %",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          }
+        }
+      ],
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 8 },
+      "unit": "percent",
+      "description": "Percentage of 5xx errors for feature serving."
+    },
+    {
+      "title": "Dashboard: Page Views",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "targets": [
+        {
+          "expr": "dashboard_page_views_total",
+          "legendFormat": "Total Page Views",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          }
+        }
+      ],
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 16 },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "title": "Dashboard: Prediction Requests",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "targets": [
+        {
+          "expr": "dashboard_prediction_requests_total",
+          "legendFormat": "Total Predictions",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          }
+        }
+      ],
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 16 },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "title": "Dashboard: Last Prediction Time",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "targets": [
+        {
+          "expr": "dashboard_last_prediction_timestamp_seconds",
+          "legendFormat": "Last Prediction",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          }
+        }
+      ],
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 16 },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s Epoch",
+          "custom": {
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    }
+  ],
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Comprehensive Service Overview",
+  "uid": "comprehensive-services-overview",
+  "version": 3
+} 

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true 

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,15 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'model-serving'
+    static_configs:
+      - targets: ['model-serving:8000']
+
+  - job_name: 'feature-serving'
+    static_configs:
+      - targets: ['feature-serving:8001']
+
+  - job_name: 'dashboard'
+    static_configs:
+      - targets: ['dashboard:9095'] 


### PR DESCRIPTION
This pull request introduces Prometheus-based monitoring and metrics collection across the application, along with Grafana dashboards for visualization. The changes span multiple components, including the dashboard, feature-serving service, and the monitoring stack. Key updates include integrating Prometheus metrics in the application code, updating the `docker-compose.yml` configuration, and adding Grafana dashboards and Prometheus scrape configurations.

### Prometheus Metrics Integration:

* **Dashboard (`dashboard/app.py`)**: Added Prometheus counters and gauges to track metrics like page views, prediction requests, and active sessions. A Prometheus metrics server is started in a separate thread for the dashboard 
* **Feature Serving (`feature_serving/main.py`)**: Integrated `prometheus-fastapi-instrumentator` to automatically expose FastAPI metrics, including request rates and latencies 
### Monitoring Stack Configuration:

* **Prometheus Configuration (`monitoring/prometheus/prometheus.yml`)**: Added scrape configurations for the dashboard, model-serving, and feature-serving services to collect metrics 
* **Grafana Datasource (`monitoring/grafana/provisioning/datasources/prometheus.yml`)**: Configured Prometheus as the default datasource in Grafana 
### Visualization Enhancements:

* **Grafana Dashboards**:
  - Added a `default.json` dashboard with panels for metrics like request rates, latencies, error rates, page views, and prediction requests 

### Docker Compose Updates:

* **`docker-compose.yml`**: Updated volume paths for Prometheus and Grafana configurations to reflect a new directory structure under `monitoring` 
### Dependency Updates:

* **`pyproject.toml`**: Added `prometheus-client` and `prometheus-fastapi-instrumentator` as dependencies for metrics instrumentation 